### PR TITLE
android-app: Correct BLE MTU setup (at least for esp-idf + nimble)

### DIFF
--- a/android-app/app/src/main/java/com/maisonsmd/catdrive/service/BroadcastService.kt
+++ b/android-app/app/src/main/java/com/maisonsmd/catdrive/service/BroadcastService.kt
@@ -214,8 +214,8 @@ class BleService : Service(), LocationListener {
                 // successfully connected to the GATT Server
                 // Attempts to discover services after successful connection.
                 Timber.i("onConnectionStateChange: Connected! ${mDevice}, ${mBluetoothGatt}")
-                mBluetoothGatt?.discoverServices()
                 mConnectionState = BluetoothProfile.STATE_CONNECTING
+                gatt?.requestMtu(517)
             } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                 // disconnected from the GATT Server
                 // broadcastUpdate(ACTION_GATT_DISCONNECTED)
@@ -234,6 +234,12 @@ class BleService : Service(), LocationListener {
                     }
                 )
             }
+        }
+
+        override fun onMtuChanged(gatt: BluetoothGatt?, mtu: Int, status: Int) {
+            super.onMtuChanged(gatt, mtu, status)
+            gatt?.discoverServices()
+            mConnectionState = BluetoothProfile.STATE_CONNECTING
         }
 
         override fun onServicesDiscovered(gatt: BluetoothGatt?, status: Int) {
@@ -342,7 +348,6 @@ class BleService : Service(), LocationListener {
         mBluetoothGatt =
             device.connectGatt(this, false, gattCallback, BluetoothDevice.TRANSPORT_LE).also {
                 it.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
-                it.requestMtu(240)
             }
     }
 


### PR DESCRIPTION
I'm implementing an esp32 project for bicycle navigation, which uses your android app. I had a problem where the navigation bitmap writes never got through to the device. After some debugging, I found out that the MTU setting didn't work as expected, which this patch fixes. I'm not sure why this is a problem on my board, but it might be that I use esp-idf + nimble, instead of the Arduino environment. My phone is a OnePlus Nord 2 with Android 13, which might also perhaps be a source of this problem.

I know nothing about Android development, so this is basically just implemented through googling for similar problems!